### PR TITLE
[SensitivityModule] new option to set output file name in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,14 @@ CMakeFiles                    cmake_install.cmake
 Makefile                      sensitivity.root
 ```
 
-The output file will always be called `sensitivity.root` so don’t run it multiple times concurrently in the same directory
+The output file will by default be called `sensitivity.root` so don’t run it multiple times concurrently in the same directory
 or you will overwrite the previous file! Use the falaise flreconstruct pipeline instructions to see how to integrate this module in your pipeline.
+
+There is now the option to configure the output filename in the module configuration file.
+The final two lines of the configuration file must read:
+
+[name="processing" type="SensitivityModule"]
+filename_out : string[1] = "my_filename.root"
 
 
 ## Output tuple structure - standard cuts

--- a/SensitivityModule.cpp
+++ b/SensitivityModule.cpp
@@ -11,10 +11,14 @@ int gammaVetoHitType=1252;
 using namespace std;
 DPP_MODULE_REGISTRATION_IMPLEMENT(SensitivityModule,"SensitivityModule");
 SensitivityModule::SensitivityModule() : dpp::base_module()
-{}
+{
+  filename_output_="sensitivity.root";
+}
+
 SensitivityModule::~SensitivityModule() {
   if (is_initialized()) this->reset();
 }
+
 void SensitivityModule::initialize(const datatools::properties& myConfig,
                                    datatools::service_manager& flServices,
                                    dpp::module_handle_dict_type& /*moduleDict*/){
@@ -31,9 +35,18 @@ void SensitivityModule::initialize(const datatools::properties& myConfig,
                 "Null pointer to geometry manager return by geometry_service");
   }
 
- // Use the method of PTD2ROOT to create a root file with just the branches we need for the sensitivity analysis
+  // Extract the filename_out key from the supplied config, if
+  // the key exists. datatools::properties throws an exception if
+  // the key isn't in the config, so catch this if thrown and don't do
+  // anything
+  try {
+    myConfig.fetch("filename_out",this->filename_output_);
+  } catch (std::logic_error& e) {
+  }
 
-  hfile_ = new TFile("sensitivity.root","RECREATE","Output file of Simulation data");
+  // Use the method of PTD2ROOT to create a root file with just the branches we need for the sensitivity analysis
+
+  hfile_ = new TFile(filename_output_.c_str(),"RECREATE","Output file of Simulation data");
   hfile_->cd();
   tree_ = new TTree("Sensitivity","Sensitivity");
   tree_->SetDirectory(hfile_);
@@ -1245,5 +1258,6 @@ void SensitivityModule::reset() {
 
   // clean up
   delete hfile_;
+  filename_output_ = "sensitivity.root";
   this->_set_initialized(false);
 }

--- a/SensitivityModule.h
+++ b/SensitivityModule.h
@@ -158,6 +158,9 @@ class SensitivityModule : public dpp::base_module {
   TTree* tree_;
   SensitivityEventStorage sensitivity_;
 
+  // configurable data member
+  std::string filename_output_;
+
   // geometry service
   const geomtools::manager* geometry_manager_; //!< The geometry manager
 

--- a/SensitivityModuleExample.conf.in
+++ b/SensitivityModuleExample.conf.in
@@ -2,15 +2,12 @@
 #@description Chain pipeline using a single custom module
 #@key_label   "name"
 #@meta_label  "type"
-
 # - Custom modules
 # The "flreconstruct.plugins" section to tell flreconstruct what
 # to load and from where.
 [name="flreconstruct.plugins" type="flreconstruct::section"]
 plugins : string[1] = "SensitivityModule"
-# Adjust this path if you put the lib elsewhere
-SensitivityModule.directory : string = "@PROJECT_BINARY_DIR@"
-
+SensitivityModule.directory : string = "/storage/epp2/phsdaq/Sandbox/Falaise/sysworkdir/SensitivityModule/build/"
 # - Pipeline configuration
 # Must define "pipeline" as this is the module flreconstruct will use
 # Make it use our custom module by setting the'type' key to the string we
@@ -19,5 +16,8 @@ SensitivityModule.directory : string = "@PROJECT_BINARY_DIR@"
 # At present, it takes no configuration, so it suffices to define it
 [name="pipeline" type="dpp::chain_module"]
 modules : string[1] = "processing"
-
+#modules : string[2] = "processing" "resultdump"
+#[name="resultdump" type="dpp::dump_module"]
+#title : string = "ResultDump"
 [name="processing" type="SensitivityModule"]
+filename_out : string[1] = "my_sensitivity.root"

--- a/SensitivityModuleExample.conf.in
+++ b/SensitivityModuleExample.conf.in
@@ -2,12 +2,15 @@
 #@description Chain pipeline using a single custom module
 #@key_label   "name"
 #@meta_label  "type"
+
 # - Custom modules
 # The "flreconstruct.plugins" section to tell flreconstruct what
 # to load and from where.
 [name="flreconstruct.plugins" type="flreconstruct::section"]
 plugins : string[1] = "SensitivityModule"
-SensitivityModule.directory : string = "/storage/epp2/phsdaq/Sandbox/Falaise/sysworkdir/SensitivityModule/build/"
+# Adjust this path if you put the lib elsewhere
+SensitivityModule.directory : string = "@PROJECT_BINARY_DIR@"
+
 # - Pipeline configuration
 # Must define "pipeline" as this is the module flreconstruct will use
 # Make it use our custom module by setting the'type' key to the string we
@@ -16,8 +19,5 @@ SensitivityModule.directory : string = "/storage/epp2/phsdaq/Sandbox/Falaise/sys
 # At present, it takes no configuration, so it suffices to define it
 [name="pipeline" type="dpp::chain_module"]
 modules : string[1] = "processing"
-#modules : string[2] = "processing" "resultdump"
-#[name="resultdump" type="dpp::dump_module"]
-#title : string = "ResultDump"
+
 [name="processing" type="SensitivityModule"]
-filename_out : string[1] = "my_sensitivity.root"


### PR DESCRIPTION
Hi Cheryl,
I needed this change to the Sensitivity Module since it needs to run on a batch cluster here at Warwick. That implies a requirement to set individual output file names. The easiest way I could see to achieve that was to implement the option to set the output file in the configuration file.
I amended the README accordingly. You can also see that only minor changes to the source and header files were required. 
The changed SensitivityModuleExample.conf.in is my mistake. Shouldn't have been committed hence remove or change as you see fit, won't do any harm,