### PR TITLE
WIP: variable for counting hits only on the foil

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ filename_out : string[1] = "my_filename.root"
 
 **reco.projection_distance_xy** : How far in the xy plane we had to project our longest-projected track. Proxy for how many cells we are claiming to have a track, but where we didn’t reconstruct a hit. Could be replaced by a mapping of broken cells etc.
 
-**reco.vertices_on_foil** : Number of charged particle tracks with a vertex on the foil.
+**reco.foil_vertex_count** : Number of charged particle tracks with a vertex on the foil.
+
+**reco.vertices_in_tracker** : Number of charged particle tracks with a vertex on the foil or on the wires (was `reco.vertices_on_foil`).
 
 **reco.electrons_from_foil** : Vector of booleans corresponding to the electron candidates in descending order of energy. True if the electron candidate has a vertex on the source foil, false if not.
 

--- a/SensitivityModule.h
+++ b/SensitivityModule.h
@@ -107,7 +107,8 @@ typedef struct SensitivityEventStorage{
   double foil_projection_separation_; // How far apart would the vertices be if the tracks were projected back to the foil? Sometimes a track will not be reconstructed all the way back even if it really was from the foil
 
   double projection_distance_xy_; // Distance between the end of the track and the foil projected vertex, in the xy plane (ie ignoring distance along wires - gives an indication of how many hits were missed). There are 2 tracks in a good event, and we want the longer of the two distances.
-  int vertices_on_foil_; // How many tracks included a vertex on the foil?
+  int foil_vertex_count_; // How many tracks included a vertex on the foil?
+  int vertices_in_tracker_; // How many tracks included a vertex on the foil or on a wire?
   std::vector<bool> electrons_from_foil_; // For each electron, is the vertex on the foil?
   
   // For calculating probability of an  internal/external topology

--- a/TrackDetails.h
+++ b/TrackDetails.h
@@ -31,6 +31,7 @@ class TrackDetails{
   TVector3 foilmostVertex_ ;
   TVector3 direction_;
   bool vertexOnFoil_=false;
+  bool vertexInTracker_=false;
   TVector3 projectedVertex_;
   enum Particle { ELECTRON, GAMMA, ALPHA, UNKNOWN };
   Particle particleType_=UNKNOWN;
@@ -111,6 +112,7 @@ public:
   double GetFoilmostVertexZ();
   TVector3 GetFoilmostVertex();
   bool HasFoilVertex();
+  bool HasTrackerVertex();
   bool TrackCrossesFoil();
   
   // Direction at foilmost end

--- a/trackDetails.cpp
+++ b/trackDetails.cpp
@@ -73,6 +73,7 @@ bool TrackDetails::Initialize()
   trackLength_ = the_trajectory.get_pattern().get_shape().get_length();
   
   // Get details about the vertex position
+  vertexInTracker_ = SetFoilmostVertex();
   vertexOnFoil_ = SetFoilmostVertex();
   if (SetDirection()) SetProjectedVertex(); // Can't project if no direction!
   
@@ -125,7 +126,7 @@ TVector3 TrackDetails::GenerateGammaTrackDirection(TrackDetails *electronTrack)
   if (!IsGamma()) return failVector; // One gamma and one electron
   if (!electronTrack->IsElectron()) return failVector;
   if (foilmostVertex_.x()==-9999 || electronTrack->GetFoilmostVertexX()==-9999) return failVector; // They need real vertex positions
-  if (!vertexOnFoil_) return failVector; // needs to share a vertex with an electron
+  if (!vertexInTracker_) return failVector; // needs to share a vertex with an electron
   direction_=(foilmostVertex_ - electronTrack->GetFoilmostVertex()).Unit();
   return direction_;
 }
@@ -293,15 +294,13 @@ bool TrackDetails::PopulateCaloHits()
       const geomtools::blur_spot & vertex = track_.get_vertices().at(iVertex).get();
       if (snemo::datamodel::particle_track::vertex_is_on_source_foil(vertex) || snemo::datamodel::particle_track::vertex_is_on_wire(vertex) )
       {
-        vertexOnFoil_ = true; // On wire OR foil - just not calo to calo gammas
+        vertexInTracker_ = true; // On wire OR foil - just not calo to calo gammas
       }
     }
   }
   
   return true;
 }
-
-
 
 // Return true if vertex is on the foil
 // Populate the inner vertex
@@ -331,6 +330,7 @@ bool TrackDetails::SetFoilmostVertex()
   }
   return hasVertexOnFoil;
 }
+
 // Populates the direction_ vector with the direction of the track at the foilmost end
 // Returns true if you managed to set it, false if not
 bool TrackDetails::SetDirection()
@@ -424,6 +424,10 @@ TVector3 TrackDetails::GetFoilmostVertex()
 bool TrackDetails::HasFoilVertex()
 {
   return vertexOnFoil_;
+}
+bool TrackDetails::HasTrackerVertex()
+{
+  return vertexInTracker_;  // was before vertexOnFoil_
 }
 // Foil-projected vertex
 double TrackDetails::GetProjectedVertexX()


### PR DESCRIPTION
Renamed variables for the vertices on the tracker (foil or wires): `reco.vertices_in_tracker`
new variable for counting hits only on the foil: `reco.foil_vertex_count`

The variable `reco.vertices_in_tracker` replaces `reco.vertices_on_foil` (misleading name) and is used in the very same parts of the code without disrupting any other function.

Mentioned in Issue #26 .