### PR TITLE
Make SensitivityModule compile with new PTD changes

### DIFF
--- a/SensitivityModule.cpp
+++ b/SensitivityModule.cpp
@@ -294,10 +294,10 @@ SensitivityModule::process(datatools::things& workItem) {
     int nCalHitsOverHighLimit=0;
     int nCalHitsOverLowLimit=0;
 
-    if (calData.has_calibrated_calorimeter_hits())
+    //if (calData.has_calibrated_calorimeter_hits())
       {
-        const snemo::datamodel::calibrated_data::calorimeter_hit_collection_type & calHits=calData.calibrated_calorimeter_hits();
-        for (snemo::datamodel::calibrated_data::calorimeter_hit_collection_type::const_iterator   iHit = calHits.begin(); iHit != calHits.end(); ++iHit) {
+        const snemo::datamodel::CalorimeterHitHdlCollection & calHits=calData.calorimeter_hits();
+        for (snemo::datamodel::CalorimeterHitHdlCollection::const_iterator   iHit = calHits.begin(); iHit != calHits.end(); ++iHit) {
           const snemo::datamodel::calibrated_calorimeter_hit & calHit = iHit->get();
           double energy=calHit.get_energy() ;
           totalCalorimeterEnergy += energy;
@@ -326,11 +326,11 @@ SensitivityModule::process(datatools::things& workItem) {
       {
         passesTwoPlusCalos=true;
       }
-      if (calData.has_calibrated_tracker_hits())
+      //if (calData.has_calibrated_tracker_hits())
       {
         // Count the delayed tracker hits by looping all the tracker hits and checking if they are delayed
-        const snemo::datamodel::calibrated_data::tracker_hit_collection_type& trackerHits = calData.calibrated_tracker_hits();
-        for (snemo::datamodel::calibrated_data::tracker_hit_collection_type::const_iterator   iHit = trackerHits.begin(); iHit != trackerHits.end(); ++iHit) {
+        const snemo::datamodel::TrackerHitHdlCollection& trackerHits = calData.tracker_hits();
+        for (snemo::datamodel::TrackerHitHdlCollection::const_iterator   iHit = trackerHits.begin(); iHit != trackerHits.end(); ++iHit) {
           const snemo::datamodel::calibrated_tracker_hit& hit = iHit->get();
           if (hit.is_delayed()) delayedHitCount++;
         }
@@ -346,15 +346,15 @@ SensitivityModule::process(datatools::things& workItem) {
   // We want two clusters of three cells
   try {
     const snemo::datamodel::tracker_clustering_data& clusterData = workItem.get<snemo::datamodel::tracker_clustering_data>("TCD");
-    if (clusterData.has_default_solution ()) // Looks as if there is a possibility of alternative solutions. Is it sufficient to use the default?
+    if (clusterData.has_default ()) // Looks as if there is a possibility of alternative solutions. Is it sufficient to use the default?
       {
-        snemo::datamodel::tracker_clustering_solution solution = clusterData.get_default_solution () ;
-        snemo::datamodel::tracker_clustering_solution::cluster_col_type clusters=solution.get_clusters();
-        for (snemo::datamodel::tracker_clustering_solution::cluster_col_type::const_iterator iCluster = clusters.begin();  iCluster != clusters.end(); ++ iCluster)
+        snemo::datamodel::tracker_clustering_solution solution = clusterData.get_default () ;
+        snemo::datamodel::TrackerClusterHdlCollection clusters=solution.get_clusters();
+        for (snemo::datamodel::TrackerClusterHdlCollection::const_iterator iCluster = clusters.begin();  iCluster != clusters.end(); ++ iCluster)
         {
           const snemo::datamodel::tracker_cluster & cluster = iCluster->get();
 
-          if (cluster.get_number_of_hits()>=minHitsInCluster) ++clusterCount;
+          if (cluster.size()>=minHitsInCluster) ++clusterCount;
             else ++smallClusterCount;
         }
       }
@@ -377,10 +377,10 @@ SensitivityModule::process(datatools::things& workItem) {
   {
     const snemo::datamodel::particle_track_data& trackData = workItem.get<snemo::datamodel::particle_track_data>("PTD");
     
-    if (trackData.has_particles ())
+    if (trackData.hasParticles ())
     {
 
-      for (uint iParticle=0;iParticle<trackData.get_number_of_particles();++iParticle)
+      for (uint iParticle=0;iParticle<trackData.numberOfParticles();++iParticle)
       {
 
         snemo::datamodel::particle_track track=trackData.get_particle(iParticle);

--- a/SensitivityModule.cpp
+++ b/SensitivityModule.cpp
@@ -558,6 +558,7 @@ SensitivityModule::process(datatools::things& workItem) {
           if (energy > higherTrueEnergy)
           {
             lowerTrueEnergy=higherTrueEnergy;
+            lowerTrueType=higherTrueType;
             higherTrueEnergy=energy;
             higherTrueType=type;
           }

--- a/SensitivityModule.cpp
+++ b/SensitivityModule.cpp
@@ -380,10 +380,13 @@ SensitivityModule::process(datatools::things& workItem) {
     if (trackData.hasParticles ())
     {
 
-      for (uint iParticle=0;iParticle<trackData.numberOfParticles();++iParticle)
-      {
+      const snemo::datamodel::ParticleHdlCollection particles = trackData.particles();
+      for (snemo::datamodel::ParticleHdlCollection::const_iterator   iParticle = particles.begin(); iParticle != particles.end(); ++iParticle) {
+        const snemo::datamodel::particle_track& track = iParticle->get();
+  //    for (uint iParticle=0;iParticle<trackData.numberOfParticles();++iParticle)
+   //   {
 
-        snemo::datamodel::particle_track track=trackData.get_particle(iParticle);
+     //   snemo::datamodel::particle_track track=trackData.get_particle(iParticle);
         TrackDetails trackDetails(geometry_manager_, track);
         
         // Populate info for gammas

--- a/SensitivityModule.cpp
+++ b/SensitivityModule.cpp
@@ -522,11 +522,8 @@ SensitivityModule::process(datatools::things& workItem) {
         passesAssociatedCalorimeters=true;
         twoParticles.push_back(&electronCandidateDetails.at(1));
       }
-      if (twoParticles.at(0)->GetTrackLength()>0 && twoParticles.at(1)->GetTrackLength()>0)
-      {
-       CalculateProbabilities(internalProbability, externalProbability,  twoParticles,  false);
-       CalculateProbabilities(foilProjectedInternalProbability, foilProjectedExternalProbability,  twoParticles,  true);
-      } // Don't try to calculate the probabilities if there is no track length (reconstruction error)
+      CalculateProbabilities(internalProbability, externalProbability,  twoParticles,  false);
+      CalculateProbabilities(foilProjectedInternalProbability, foilProjectedExternalProbability,  twoParticles,  true);
     }// end if either 2e or 1e n gamma
   }// end try on PTD bank
   catch (std::logic_error& e) {
@@ -829,12 +826,6 @@ void SensitivityModule::CalculateProbabilities(double &internalProbability, doub
 // Calculate probabilities for an internal (both particles from the foil) and external (calo 1 -> foil -> calo 2) topology
 void SensitivityModule::CalculateProbabilities(double &internalProbability, double &externalProbability, double *calorimeterEnergies,  double *betas, double *trackLengths, double *calorimeterTimes, double *totalTimeVariances )
 {
-  if (trackLengths[0] * trackLengths[1] == 0 || betas[0] * betas[1] == 0)
-  { // We will not get a real answer if these aren't set to something real
-    internalProbability=-1;
-    externalProbability=-1;
-    return;
-  }
   double theoreticalTimeOfFlight[2];
   double internalEmissionTime[2];
   double internalChiSquared;

--- a/trackDetails.cpp
+++ b/trackDetails.cpp
@@ -69,7 +69,7 @@ bool TrackDetails::Initialize()
   const snemo::datamodel::tracker_cluster & the_cluster = the_trajectory.get_cluster();
   
   // Number of hits and lengths of track
-  trackerHitCount_ = the_cluster.get_number_of_hits(); // Currently a track only contains 1 cluster
+  trackerHitCount_ = the_cluster.size(); // Currently a track only contains 1 cluster
   trackLength_ = the_trajectory.get_pattern().get_shape().get_length();
   
   // Get details about the vertex position
@@ -81,7 +81,14 @@ bool TrackDetails::Initialize()
   if (track_.get_charge()==snemo::datamodel::particle_track::UNDEFINED && !track_.has_associated_calorimeter_hits() && the_cluster.is_delayed()>0)
   {
     particleType_=ALPHA;
-    delayTime_ = (the_cluster.get_hit(0).get_delayed_time());
+    
+    const snemo::datamodel::TrackerHitHdlCollection& trackerHits = the_cluster.hits();
+    // iterate only once, we only want the first hit
+    for (snemo::datamodel::TrackerHitHdlCollection::const_iterator   iHit = trackerHits.begin(); iHit > trackerHits.begin(); ++iHit) {
+      const snemo::datamodel::calibrated_tracker_hit& a_delayed_gg_hit = iHit->get();
+      delayTime_ = (a_delayed_gg_hit.get_delayed_time());
+    }
+    
     return true;
   }
   // ELECTRON candidates are prompt and have an associated calorimeter hit. No charge requirement as yet
@@ -146,10 +153,9 @@ bool TrackDetails::GenerateAlphaProjections(TrackDetails *electronTrack)
   
   //want to store the vector position of the delayed hit
 
-  int noHits = the_cluster.get_number_of_hits();
-  for (int hitNumber=0; hitNumber < noHits; hitNumber++)
-  {
-      const snemo::datamodel::calibrated_tracker_hit &a_delayed_gg_hit = the_cluster.get_hit(hitNumber);
+  const snemo::datamodel::TrackerHitHdlCollection& trackerHits = the_cluster.hits();
+  for (snemo::datamodel::TrackerHitHdlCollection::const_iterator   iHit = trackerHits.begin(); iHit != trackerHits.end(); ++iHit) {
+    const snemo::datamodel::calibrated_tracker_hit& a_delayed_gg_hit = iHit->get();
       TVector3 delayedHitPos;
       delayedHitPos.SetXYZ(a_delayed_gg_hit.get_x(), a_delayed_gg_hit.get_y(), a_delayed_gg_hit.get_z());
       vertexPositionDelayedHit.push_back(delayedHitPos);

--- a/trackDetails.cpp
+++ b/trackDetails.cpp
@@ -336,8 +336,6 @@ bool TrackDetails::SetFoilmostVertex()
 bool TrackDetails::SetDirection()
 {
   if ( !hasTrack_) return false;
-  if (GetTrackLength()==0 ) return false; // Makes no sense
-
   if (!track_.has_trajectory()) return false; // Can't get the direction without a trajectory!
   const snemo::datamodel::base_trajectory_pattern & the_base_pattern = track_.get_trajectory().get_pattern();
   geomtools::vector_3d foilmost_end;


### PR DESCRIPTION
Updated SensitivityModule so that it will build against the latest Falaise 4 version with new syntax for various parts of the data model (issue #28 ). Test should be to check that branches are filled and correspond to the right info (compare with flvisualize). This should include events with electron, positron, gamma and alpha candidates. No need to test calculated quantities - those didn't change - it's things like electron and gamma energies & charges; cluster, track and hit counts; delayed hit times. I also fixed a bug in the true lower particle type so can you sanity check that too.
@willquinn would you be able to test this for me? 