### PR TITLE
Allow SensitivityModule to run with both Falaise 4.X and develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         docker exec builder bash -c "ls -larth $GITHUB_WORKSPACE"
         docker exec builder bash -c "mkdir build"
-        docker exec builder bash -c "cd build && CC=gcc-7 CXX=g++-7 cmake $GITHUB_WORKSPACE && make && make test"
+        docker exec builder bash -c "cd build && CC=gcc-7 CXX=g++-7 cmake $GITHUB_WORKSPACE && make && ctest -VV"
 
   build-and-test-release:
     runs-on: ubuntu-latest
@@ -39,6 +39,6 @@ jobs:
       run: |
         docker exec builder bash -c "ls -larth $GITHUB_WORKSPACE"
         docker exec builder bash -c "mkdir build"
-        docker exec builder bash -c "cd build && CC=gcc-7 CXX=g++-7 cmake $GITHUB_WORKSPACE && make && make test"
+        docker exec builder bash -c "cd build && CC=gcc-7 CXX=g++-7 cmake $GITHUB_WORKSPACE && make && ctest -VV"
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         docker exec builder bash -c "ls -larth $GITHUB_WORKSPACE"
         docker exec builder bash -c "mkdir build"
-        docker exec builder bash -c "cd build && CC=gcc-7 CXX=g++-7 cmake $GITHUB_WORKSPACE && make && ctest -VV"
+        docker exec builder bash -c "cd build && CC=gcc-7 CXX=g++-7 cmake $GITHUB_WORKSPACE && make && USER=snemo ctest -VV"
 
   build-and-test-release:
     runs-on: ubuntu-latest
@@ -39,6 +39,6 @@ jobs:
       run: |
         docker exec builder bash -c "ls -larth $GITHUB_WORKSPACE"
         docker exec builder bash -c "mkdir build"
-        docker exec builder bash -c "cd build && CC=gcc-7 CXX=g++-7 cmake $GITHUB_WORKSPACE && make && ctest -VV"
+        docker exec builder bash -c "cd build && CC=gcc-7 CXX=g++-7 cmake $GITHUB_WORKSPACE && make && USER=snemo ctest -VV"
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,22 +5,40 @@ on:
     branches: [ master ]
 
 jobs:
-  build-and-test:
+  build-and-test-develop:
     runs-on: ubuntu-latest
     steps:
     # Manually pull/start image/container due to its permission/USER.
     - name: Pull Falaise Docker Image
       run: docker pull supernemo/falaise-centos7-base:develop
     - name: Create Docker Container
-      run: docker run -itd --name builder -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE supernemo/falaise-centos7-base:develop 
+      run: docker run -itd --name builder -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE supernemo/falaise-centos7-base:develop
     - name: Install Falaise@HEAD
-      run: docker exec builder bash -c "brew install falaise --HEAD --cc=gcc-7"   
+      run: docker exec builder bash -c "brew install falaise --HEAD --cc=gcc-7"
     # Now the actual build...
     - uses: actions/checkout@v2
     - name: Check our environment
       run: |
         docker exec builder bash -c "ls -larth $GITHUB_WORKSPACE"
         docker exec builder bash -c "mkdir build"
-        docker exec builder bash -c "cd build && CC=gcc-7 CXX=g++-7 cmake $GITHUB_WORKSPACE && make"
-        
-        
+        docker exec builder bash -c "cd build && CC=gcc-7 CXX=g++-7 cmake $GITHUB_WORKSPACE && make && make test"
+
+  build-and-test-release:
+    runs-on: ubuntu-latest
+    steps:
+    # Manually pull/start image/container due to its permission/USER.
+    - name: Pull Falaise Docker Image
+      run: docker pull supernemo/falaise-centos7-base:develop
+    - name: Create Docker Container
+      run: docker run -itd --name builder -v $GITHUB_WORKSPACE:$GITHUB_WORKSPACE supernemo/falaise-centos7-base:develop
+    - name: Install Falaise
+      run: docker exec builder bash -c "brew install falaise --cc=gcc-7"
+    # Now the actual build...
+    - uses: actions/checkout@v2
+    - name: Check our environment
+      run: |
+        docker exec builder bash -c "ls -larth $GITHUB_WORKSPACE"
+        docker exec builder bash -c "mkdir build"
+        docker exec builder bash -c "cd build && CC=gcc-7 CXX=g++-7 cmake $GITHUB_WORKSPACE && make && make test"
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,20 @@
 # Declare project, which will configure compiler for us
 cmake_minimum_required(VERSION 3.3)
 project(SensitivityModule)
+
 find_package(Falaise REQUIRED)
+# - Workaround bug in CAMPConfig.cmake: it does not add its include path as a usage requirement
+set_target_properties(camp::camp PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${CAMP_INCLUDE_DIRS})
 
 # Check Falaise datamodel API, which changes between 4.0.x and develop
 try_compile(NEW_DATAMODEL_API ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/testFalaiseAPI.cc
   LINK_LIBRARIES Falaise::Falaise)
+set(__preamble "Checking for new Falaise API -")
+if(NEW_DATAMODEL_API)
+  message(STATUS "${__preamble} Success")
+else()
+  message(STATUS "${__preamble} Failed")
+endif()
 
 # Build a dynamic library from our sources
 add_library(SensitivityModule SHARED SensitivityModule.h SensitivityModule.cpp TrackDetails.h trackDetails.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,13 @@ cmake_minimum_required(VERSION 3.3)
 project(SensitivityModule)
 find_package(Falaise REQUIRED)
 
+# Check Falaise datamodel API, which changes between 4.0.x and develop
+try_compile(NEW_DATAMODEL_API ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/testFalaiseAPI.cc
+  LINK_LIBRARIES Falaise::Falaise)
+
 # Build a dynamic library from our sources
 add_library(SensitivityModule SHARED SensitivityModule.h SensitivityModule.cpp TrackDetails.h trackDetails.cpp)
+target_compile_definitions(SensitivityModule PRIVATE $<$<BOOL:${NEW_DATAMODEL_API}>:NEW_DATAMODEL_API>)
 
 # Link it to the FalaiseModule library
 # This ensures the correct compiler flags, include paths

--- a/SensitivityModule.cpp
+++ b/SensitivityModule.cpp
@@ -47,16 +47,16 @@ void SensitivityModule::initialize(const datatools::properties& myConfig,
   hfile_->cd();
   tree_ = new TTree("Sensitivity","Sensitivity");
   tree_->SetDirectory(hfile_);
-  
+
   // Reconstructed quantities
-  
+
   // Standard cuts
   tree_->Branch("reco.passes_two_calorimeters",&sensitivity_.passes_two_calorimeters_);
   tree_->Branch("reco.passes_two_plus_calos",&sensitivity_.passes_two_plus_calos_);
   tree_->Branch("reco.passes_two_clusters",&sensitivity_.passes_two_clusters_);
   tree_->Branch("reco.passes_two_tracks",&sensitivity_.passes_two_tracks_);
   tree_->Branch("reco.passes_associated_calorimeters",&sensitivity_.passes_associated_calorimeters_);
-  
+
   // Some basic counts
   tree_->Branch("reco.calorimeter_hit_count",&sensitivity_.calorimeter_hit_count_);
   tree_->Branch("reco.cluster_count",&sensitivity_.cluster_count_);
@@ -64,13 +64,13 @@ void SensitivityModule::initialize(const datatools::properties& myConfig,
   tree_->Branch("reco.associated_track_count",&sensitivity_.associated_track_count_);
   tree_->Branch("reco.small_cluster_count",&sensitivity_.small_cluster_count_);
   tree_->Branch("reco.delayed_hit_count",&sensitivity_.delayed_hit_count_);
-  
+
   // Numbers of reconstructed particles
   tree_->Branch("reco.number_of_electrons",&sensitivity_.number_of_electrons_);
   tree_->Branch("reco.electron_charges",&sensitivity_.electron_charges_);
   tree_->Branch("reco.number_of_gammas",&sensitivity_.number_of_gammas_);
   tree_->Branch("reco.alpha_count",&sensitivity_.alpha_count_);
-  
+
   // Energies
   tree_->Branch("reco.total_calorimeter_energy",&sensitivity_.total_calorimeter_energy_);
   tree_->Branch("reco.higher_electron_energy",&sensitivity_.higher_electron_energy_);
@@ -78,11 +78,11 @@ void SensitivityModule::initialize(const datatools::properties& myConfig,
   tree_->Branch("reco.electron_energies",&sensitivity_.electron_energies_);
   tree_->Branch("reco.gamma_energies",&sensitivity_.gamma_energies_);
   tree_->Branch("reco.highest_gamma_energy",&sensitivity_.highest_gamma_energy_);
-  
+
   // Electron track lengths
   tree_->Branch("reco.electron_track_lengths",&sensitivity_.electron_track_lengths_);
   tree_->Branch("reco.electron_hit_counts",&sensitivity_.electron_hit_counts_);
-  
+
   // Vertex positions (max 2 tracks)
   tree_->Branch("reco.first_vertex_x",&sensitivity_.first_vertex_x_);
   tree_->Branch("reco.first_vertex_y",&sensitivity_.first_vertex_y_);
@@ -120,7 +120,7 @@ void SensitivityModule::initialize(const datatools::properties& myConfig,
   tree_->Branch("reco.alpha_proj_vertex_y",&sensitivity_.alpha_proj_vertex_y_); // vector
   tree_->Branch("reco.alpha_proj_vertex_z",&sensitivity_.alpha_proj_vertex_z_); // vector
   tree_->Branch("reco.edgemost_vertex",&sensitivity_.edgemost_vertex_);
-  
+
   // Topologies
   tree_->Branch("reco.topology_1e1gamma",&sensitivity_.topology_1e1gamma_);
   tree_->Branch("reco.topology_1e1alpha",&sensitivity_.topology_1e1alpha_);
@@ -128,7 +128,7 @@ void SensitivityModule::initialize(const datatools::properties& myConfig,
   tree_->Branch("reco.topology_2e",&sensitivity_.topology_2e_);
   tree_->Branch("reco.topology_1e",&sensitivity_.topology_1e_);
 
-  
+
   // Multi-track topology info
   tree_->Branch("reco.angle_between_tracks",&sensitivity_.angle_between_tracks_);
   tree_->Branch("reco.same_side_of_foil",&sensitivity_.same_side_of_foil_);
@@ -151,8 +151,8 @@ void SensitivityModule::initialize(const datatools::properties& myConfig,
   tree_->Branch("reco.alpha_track_length",&sensitivity_.alpha_track_length_);
   tree_->Branch("reco.proj_track_length_alpha",&sensitivity_.proj_track_length_alpha_);
   tree_->Branch("reco.alpha_crosses_foil",&sensitivity_.alpha_crosses_foil_);
-  
-  
+
+
   // Calorimeter positions
   tree_->Branch("reco.electron_hits_mainwall",&sensitivity_.electron_hits_mainwall_);
   tree_->Branch("reco.electron_hits_xwall",&sensitivity_.electron_hits_xwall_);
@@ -174,14 +174,14 @@ void SensitivityModule::initialize(const datatools::properties& myConfig,
   tree_->Branch("true.vertex_y",&sensitivity_.true_vertex_y_);
   tree_->Branch("true.vertex_z",&sensitivity_.true_vertex_z_);
 
-  
+
   this->_set_initialized(true);
 }
 //! [SensitivityModule::Process]
 dpp::base_module::process_status
 SensitivityModule::process(datatools::things& workItem) {
-  
-  
+
+
   // internal variables to mimic the ntuple variables, names are same but in camel case
   bool passesTwoCalorimeters=false;
   bool passesTwoPlusCalos=false;
@@ -265,17 +265,17 @@ SensitivityModule::process(datatools::things& workItem) {
   std::vector<double>gammaVetoFraction;
 
   std::vector<double> trajClDelayedTime;
-  
+
   std::vector<TVector3> electronVertices;
   std::vector<TVector3> electronDirections;
   std::vector<TVector3> electronProjVertices;
   std::vector<TVector3> alphaVertices;
   std::vector<TVector3> alphaDirections;
   std::vector<TVector3> alphaProjVertices;
-  
+
   TVector3 gammaDirection; // We are only calculating this for the highest-energy gamma right now
   gammaDirection.SetXYZ(0,0,0);
-  
+
   double angleBetweenTracks;
   bool sameSideOfFoil=false;
   bool edgemostJoinedElectron=false;
@@ -285,8 +285,8 @@ SensitivityModule::process(datatools::things& workItem) {
   // Grab calibrated data bank
   // Calibrated data will only be present in reconstructed files,
   // so wrap in a try block
-  
-  
+
+
   try {
     const snemo::datamodel::calibrated_data& calData = workItem.get<snemo::datamodel::calibrated_data>("CD");
 
@@ -296,9 +296,14 @@ SensitivityModule::process(datatools::things& workItem) {
 
     //if (calData.has_calibrated_calorimeter_hits())
       {
+        #ifdef NEW_DATAMODEL_API
         const snemo::datamodel::CalorimeterHitHdlCollection & calHits=calData.calorimeter_hits();
-        for (snemo::datamodel::CalorimeterHitHdlCollection::const_iterator   iHit = calHits.begin(); iHit != calHits.end(); ++iHit) {
-          const snemo::datamodel::calibrated_calorimeter_hit & calHit = iHit->get();
+        #else
+        const snemo::datamodel::calibrated_calorimeter_hit::collection_type& calHits = calData.calibrated_calorimeter_hits();
+        #endif
+
+        for (const auto& iHit : calHits) {
+          const snemo::datamodel::calibrated_calorimeter_hit & calHit = iHit.get();
           double energy=calHit.get_energy() ;
           totalCalorimeterEnergy += energy;
 
@@ -316,7 +321,7 @@ SensitivityModule::process(datatools::things& workItem) {
 
         }
       }
-    
+
       caloHitCount=nCalHitsOverLowLimit;
       if (nCalorimeterHits==2 && nCalHitsOverHighLimit>=1 && nCalHitsOverLowLimit==2)
         {
@@ -329,9 +334,14 @@ SensitivityModule::process(datatools::things& workItem) {
       //if (calData.has_calibrated_tracker_hits())
       {
         // Count the delayed tracker hits by looping all the tracker hits and checking if they are delayed
+        #ifdef NEW_DATAMODEL_API
         const snemo::datamodel::TrackerHitHdlCollection& trackerHits = calData.tracker_hits();
-        for (snemo::datamodel::TrackerHitHdlCollection::const_iterator   iHit = trackerHits.begin(); iHit != trackerHits.end(); ++iHit) {
-          const snemo::datamodel::calibrated_tracker_hit& hit = iHit->get();
+        #else
+        const snemo::datamodel::calibrated_tracker_hit::collection_type& trackerHits = calData.calibrated_tracker_hits();
+        #endif
+
+        for (const auto& iHit : trackerHits) {
+          const snemo::datamodel::calibrated_tracker_hit& hit = iHit.get();
           if (hit.is_delayed()) delayedHitCount++;
         }
 
@@ -346,16 +356,39 @@ SensitivityModule::process(datatools::things& workItem) {
   // We want two clusters of three cells
   try {
     const snemo::datamodel::tracker_clustering_data& clusterData = workItem.get<snemo::datamodel::tracker_clustering_data>("TCD");
-    if (clusterData.has_default ()) // Looks as if there is a possibility of alternative solutions. Is it sufficient to use the default?
-      {
-        snemo::datamodel::tracker_clustering_solution solution = clusterData.get_default () ;
-        snemo::datamodel::TrackerClusterHdlCollection clusters=solution.get_clusters();
-        for (snemo::datamodel::TrackerClusterHdlCollection::const_iterator iCluster = clusters.begin();  iCluster != clusters.end(); ++ iCluster)
-        {
-          const snemo::datamodel::tracker_cluster & cluster = iCluster->get();
 
-          if (cluster.size()>=minHitsInCluster) ++clusterCount;
-            else ++smallClusterCount;
+    #ifdef NEW_DATAMODEL_API
+    bool clusterHasDefaultSolution = clusterData.has_default();
+    #else
+    bool clusterHasDefaultSolution = clusterData.has_default_solution();
+    #endif
+
+    if (clusterHasDefaultSolution) // Looks as if there is a possibility of alternative solutions. Is it sufficient to use the default?
+      {
+        #ifdef NEW_DATAMODEL_API
+        snemo::datamodel::tracker_clustering_solution solution = clusterData.get_default() ;
+        const snemo::datamodel::TrackerClusterHdlCollection& clusters=solution.get_clusters();
+        #else
+        snemo::datamodel::tracker_clustering_solution solution = clusterData.get_default_solution();
+        const snemo::datamodel::tracker_clustering_solution::cluster_col_type& clusters = solution.get_clusters();
+        #endif
+
+        for (const auto& iCluster : clusters)
+        {
+          const snemo::datamodel::tracker_cluster & cluster = iCluster.get();
+
+          #ifdef NEW_DATAMODEL_API
+          bool hasAtLeastMinHits = (cluster.size() >= minHitsInCluster);
+          #else
+          bool hasAtLeastMinHits = (cluster.get_number_of_hits() >= minHitsInCluster);
+          #endif
+
+          if (hasAtLeastMinHits) {
+            ++clusterCount;
+          }
+          else {
+            ++smallClusterCount;
+          }
         }
       }
     if (clusterCount==2 )
@@ -376,19 +409,26 @@ SensitivityModule::process(datatools::things& workItem) {
   try
   {
     const snemo::datamodel::particle_track_data& trackData = workItem.get<snemo::datamodel::particle_track_data>("PTD");
-    
-    if (trackData.hasParticles ())
+
+    #ifdef NEW_DATAMODEL_API
+    bool havePTDParticles = trackData.hasParticles();
+    #else
+    bool havePTDParticles = trackData.has_particles();
+    #endif
+
+    if (havePTDParticles)
     {
+      #ifdef NEW_DATAMODEL_API
+      const snemo::datamodel::ParticleHdlCollection& particles = trackData.particles();
+      #else
+      const snemo::datamodel::particle_track_data::particle_collection_type& particles = trackData.get_particles();
+      #endif
 
-      const snemo::datamodel::ParticleHdlCollection particles = trackData.particles();
-      for (snemo::datamodel::ParticleHdlCollection::const_iterator   iParticle = particles.begin(); iParticle != particles.end(); ++iParticle) {
-        const snemo::datamodel::particle_track& track = iParticle->get();
-  //    for (uint iParticle=0;iParticle<trackData.numberOfParticles();++iParticle)
-   //   {
+      for (const auto& iParticle : particles) {
+        const snemo::datamodel::particle_track& track = iParticle.get();
 
-     //   snemo::datamodel::particle_track track=trackData.get_particle(iParticle);
         TrackDetails trackDetails(geometry_manager_, track);
-        
+
         // Populate info for gammas
         if (trackDetails.IsGamma())
         {
@@ -404,7 +444,7 @@ SensitivityModule::process(datatools::things& workItem) {
           InsertAt(trackDetails,gammaCandidateDetails,pos);
           continue;
         }
-        
+
         if (trackDetails.MakesTrack()) trackCount++;
         else continue;
 
@@ -428,7 +468,7 @@ SensitivityModule::process(datatools::things& workItem) {
 
         double thisY = trackDetails.GetFoilmostVertexY();
         if (TMath::Abs(thisY) > TMath::Abs(edgemostVertex)) edgemostVertex = thisY;
-        
+
         // For electron candidates, we need to store the energies
         if (trackDetails.IsElectron())
         {
@@ -453,7 +493,7 @@ SensitivityModule::process(datatools::things& workItem) {
           InsertAt(trackDetails.GetProjectedTrackLength(),electronProjTrackLengths,pos);
           InsertAt(trackDetails.GetTrackerHitCount(),electronHitCounts,pos);
         }
-        
+
         // Now look for alpha candidates
         if (trackDetails.IsAlpha())
         {
@@ -487,17 +527,17 @@ SensitivityModule::process(datatools::things& workItem) {
     {
       is1electron = true;
     }
-    
+
     if (electronCandidates.size() ==1 && alphaCandidates.size() ==1 && trackCount==2)
     { // gammas allowed
       is1e1alpha = true;
     }
-    
+
 
     //---------------------------------------
     // Combined info for the topologies
     //---------------------------------------
-    
+
     // Calculate values for the 1e1alpha topology
     // Want to iterate over the tracks in the electronCandidate and alphaCandidate vectors
     if (is1e1alpha)
@@ -592,11 +632,11 @@ SensitivityModule::process(datatools::things& workItem) {
   highestGammaEnergy=0;
   if (gammaCandidates.size()>0) highestGammaEnergy=gammaEnergies.at(0);
 
-  
+
   // Initialise variables that might not otherwise get set
   // It does not restart the vector for each entry so we have to do that manually
   ResetVars();
-  
+
   // Cuts pass/fail
   sensitivity_.passes_two_calorimeters_ = passesTwoCalorimeters;
   sensitivity_.passes_two_plus_calos_ = passesTwoPlusCalos;
@@ -621,8 +661,8 @@ SensitivityModule::process(datatools::things& workItem) {
 
   // And the new vertex vectors - we can rely on these all being the same size of vectors as we populate them all together
 
-  
-  
+
+
   for (int i=0;i<electronVertices.size();i++)
   {
     sensitivity_.electron_vertex_x_.push_back(electronVertices.at(i).X());
@@ -648,7 +688,7 @@ SensitivityModule::process(datatools::things& workItem) {
     sensitivity_.alpha_dir_y_.push_back(alphaDirections.at(i).Y());
     sensitivity_.alpha_dir_z_.push_back(alphaDirections.at(i).Z());
   }
-  
+
   // Special vertex variables
   if (is2electron || is1e1alpha)
     // At the moment we only set these for these two topologies. This should possibly change
@@ -674,20 +714,20 @@ SensitivityModule::process(datatools::things& workItem) {
     sensitivity_.second_track_direction_x_= electronDirections.at(1).X();
     sensitivity_.second_track_direction_y_= electronDirections.at(1).Y();
     sensitivity_.second_track_direction_z_= electronDirections.at(1).Z();
-    
+
     sensitivity_.vertex_separation_= (electronVertices.at(0) - electronVertices.at(1)).Mag();
     sensitivity_.foil_projection_separation_= (electronProjVertices.at(0) - electronProjVertices.at(1)).Mag();
     sensitivity_.angle_between_tracks_= electronDirections.at(0).Angle(electronDirections.at(1));
-    
+
     double thisProjectionDistance=(electronVertices.at(1)-electronProjVertices.at(1)).Perp();
     if (thisProjectionDistance > projectionDistanceXY)projectionDistanceXY=thisProjectionDistance;
   }
-  
+
   if(is1engamma && (gammaDirection.Mag()>0))
   {
     sensitivity_.angle_between_tracks_= electronDirections.at(0).Angle(gammaDirection);
   }
-  
+
   if(is1e1alpha)
   {
     sensitivity_.alpha_track_length_=alphaCandidateDetails.at(0).GetTrackLength();
@@ -703,17 +743,17 @@ SensitivityModule::process(datatools::things& workItem) {
     sensitivity_.second_track_direction_x_= alphaDirections.at(0).X();
     sensitivity_.second_track_direction_y_= alphaDirections.at(0).Y();
     sensitivity_.second_track_direction_z_= alphaDirections.at(0).Z();
-    
+
       // Some two-particle topology calculations
     sensitivity_.vertex_separation_=(electronVertices.at(0) - alphaVertices.at(0)).Mag();
     sensitivity_.foil_projection_separation_= (electronProjVertices.at(0) - alphaCandidateDetails.at(0).GetProjectedVertex()).Mag();
     sensitivity_.angle_between_tracks_= electronDirections.at(0).Angle(alphaDirections.at(0));
-    
+
     double thisProjectionDistance=(alphaVertices.at(0)-alphaProjVertices.at(0)).Perp();
     if (thisProjectionDistance > projectionDistanceXY)projectionDistanceXY=thisProjectionDistance;
 
   }
-  
+
   // Track direction
   if (is2electron || is1e1alpha) // This works in either case
     {
@@ -728,8 +768,8 @@ SensitivityModule::process(datatools::things& workItem) {
   sensitivity_.electrons_from_foil_=electronsFromFoil;
   sensitivity_.electron_track_lengths_=electronTrackLengths;
   sensitivity_.electron_hit_counts_=electronHitCounts;
-  
- 
+
+
   // Timing
   sensitivity_.calo_hit_time_separation_=TMath::Abs(timeDelay);
   sensitivity_.delayed_track_time_= &trajClDelayedTime;
@@ -746,7 +786,7 @@ SensitivityModule::process(datatools::things& workItem) {
   sensitivity_.topology_1e1alpha_=is1e1alpha;
   sensitivity_.topology_2e_=is2electron;
   sensitivity_.topology_1e_=is1electron;
-  
+
 
   // Calorimeter walls: fractions of energy in each and vector of booleans
   // to say whether there are any hits in that wall
@@ -768,7 +808,7 @@ SensitivityModule::process(datatools::things& workItem) {
   sensitivity_.alpha_count_=alphaCandidates.size();
   sensitivity_.delayed_cluster_hit_count_=delayedClusterHitCount;
   sensitivity_.delayed_hit_count_=delayedHitCount;
-  
+
   // Truth info, simulation only
   sensitivity_.true_highest_primary_energy_=higherTrueEnergy;
   sensitivity_.true_second_primary_energy_=lowerTrueEnergy;
@@ -778,9 +818,9 @@ SensitivityModule::process(datatools::things& workItem) {
   sensitivity_.true_vertex_x_=trueVertexX;
   sensitivity_.true_vertex_y_=trueVertexY;
   sensitivity_.true_vertex_z_=trueVertexZ;
-  
+
   tree_->Fill();
-  
+
   // MUST return a status, see ref dpp::processing_status_flags_type
   return dpp::base_module::PROCESS_OK;
 }
@@ -807,17 +847,17 @@ void SensitivityModule::CalculateProbabilities(double &internalProbability, doub
     }
     // Calculate internal probability: both particles emitted at the same time
     // so time between the calo hits should be Time of flight 1 - Time of flight 2
-  
+
   // Calculate external probability: one particle travels to foil then the other travels from foil
   // so time between the calo hits should be Time of flight  1 + Time of flight  2
   if (projected)
   {
     internalChiSquared = pow((internalEmissionTime[0] - internalEmissionTime[1]) ,2) / (twoParticles.at(0)->GetProjectedTimeVariance() + twoParticles.at(1)->GetProjectedTimeVariance()) ;
-    
+
     externalChiSquared=pow(( TMath::Abs(twoParticles.at(0)->GetTime()-twoParticles.at(1)->GetTime()) - (theoreticalTimeOfFlight[0]+theoreticalTimeOfFlight[1]) ),2)/ (twoParticles.at(0)->GetProjectedTimeVariance() + twoParticles.at(1)->GetProjectedTimeVariance()) ;
   }else
   {
-    
+
     internalChiSquared = pow((internalEmissionTime[0] - internalEmissionTime[1]) ,2) / (twoParticles.at(0)->GetTotalTimeVariance() + twoParticles.at(1)->GetTotalTimeVariance()) ;
     externalChiSquared=pow(( TMath::Abs(twoParticles.at(0)->GetTime()-twoParticles.at(1)->GetTime()) - (theoreticalTimeOfFlight[0]+theoreticalTimeOfFlight[1]) ),2)/(twoParticles.at(0)->GetTotalTimeVariance() + twoParticles.at(1)->GetTotalTimeVariance()) ;
   }
@@ -826,7 +866,7 @@ void SensitivityModule::CalculateProbabilities(double &internalProbability, doub
   internalProbability=this->ProbabilityFromChiSquared(internalChiSquared);
   externalProbability=this->ProbabilityFromChiSquared(externalChiSquared);
 }
-                             
+
 // Calculate probabilities for an internal (both particles from the foil) and external (calo 1 -> foil -> calo 2) topology
 void SensitivityModule::CalculateProbabilities(double &internalProbability, double &externalProbability, double *calorimeterEnergies,  double *betas, double *trackLengths, double *calorimeterTimes, double *totalTimeVariances )
 {
@@ -951,7 +991,7 @@ void SensitivityModule::ResetVars()
   sensitivity_.alpha_dir_x_.clear();
   sensitivity_.alpha_dir_y_.clear();
   sensitivity_.alpha_dir_z_.clear();
-  
+
   // And initialize the rest, what a drag
   sensitivity_.first_proj_vertex_y_ = -9999;
   sensitivity_.first_proj_vertex_z_ = -9999;

--- a/SensitivityModule.h
+++ b/SensitivityModule.h
@@ -70,8 +70,8 @@ typedef struct SensitivityEventStorage{
   double second_track_direction_x_;
   double second_track_direction_y_;
   double second_track_direction_z_;
-  
-  
+
+
   // While I will keep those for legacy (at least for now), also add vectors of electron vertices and directions
   std::vector<double> electron_vertex_x_;
   std::vector<double> electron_vertex_y_;
@@ -91,8 +91,8 @@ typedef struct SensitivityEventStorage{
   std::vector<double> alpha_proj_vertex_x_;
   std::vector<double> alpha_proj_vertex_y_;
   std::vector<double> alpha_proj_vertex_z_;
-  
-  
+
+
   // Use these to estimate the vertex position if the vertex were on the foil (x=0)
   // We only need y and z values for these, as x will always be 0 by definition
   double first_proj_vertex_y_;
@@ -110,7 +110,7 @@ typedef struct SensitivityEventStorage{
   int foil_vertex_count_; // How many tracks included a vertex on the foil?
   int vertices_in_tracker_; // How many tracks included a vertex on the foil or on a wire?
   std::vector<bool> electrons_from_foil_; // For each electron, is the vertex on the foil?
-  
+
   // For calculating probability of an  internal/external topology
   double calo_hit_time_separation_;
   bool topology_2e_; // Does it have a 2-electron-like topology?
@@ -154,7 +154,7 @@ typedef struct SensitivityEventStorage{
   double alpha_track_length_; // Length of the alpha track in mm, different metrics for different numbers of delayed hits
   double proj_track_length_alpha_; // Length of the alpha track when projected back to the foil in mm
   bool alpha_crosses_foil_; // True if the alpha track crosses the foil (bug in alpha finder)
-  
+
   // Truth info - particle energies in MeV and primary vertex position
   double true_highest_primary_energy_;
   double true_second_primary_energy_;
@@ -164,7 +164,7 @@ typedef struct SensitivityEventStorage{
   double true_vertex_x_;
   double true_vertex_y_;
   double true_vertex_z_;
-  
+
 }sensitivityeventstorage;
 
 

--- a/testFalaiseAPI.cc
+++ b/testFalaiseAPI.cc
@@ -1,0 +1,6 @@
+#include "falaise/snemo/datamodels/calibrated_calorimeter_hit.h"
+
+int main(){
+  // This type is only defined in the new datamodel
+  snemo::datamodel::CalorimeterHit hit;
+}

--- a/trackDetails.cpp
+++ b/trackDetails.cpp
@@ -7,7 +7,7 @@ TrackDetails::TrackDetails()
 
 TrackDetails::TrackDetails(const geomtools::manager* geometry_manager, snemo::datamodel::particle_track track)
 {
-  
+
   foilmostVertex_.SetXYZ(-9999,-9999,-9999);
   direction_.SetXYZ(-9999,-9999,-9999);
   projectedVertex_.SetXYZ(-9999,-9999,-9999);
@@ -39,7 +39,7 @@ bool TrackDetails::Initialize()
       PopulateCaloHits();
       return true;
     } // end case neutral (gammas)
-    
+
     // Any of these will make a track
     case snemo::datamodel::particle_track::POSITIVE:
     case snemo::datamodel::particle_track::NEGATIVE:
@@ -52,14 +52,14 @@ bool TrackDetails::Initialize()
       return false;
     }
   }//end switch
-  
+
 
   if (!track_.has_trajectory())
   {
     particleType_=UNKNOWN;
     return false;
   }
-  
+
   // Now we have only charged particles remaining there are a few things we can do:
   // Identify electron candidates
   // Identify alpha candidates
@@ -67,34 +67,43 @@ bool TrackDetails::Initialize()
 
   const snemo::datamodel::tracker_trajectory & the_trajectory = track_.get_trajectory();
   const snemo::datamodel::tracker_cluster & the_cluster = the_trajectory.get_cluster();
-  
+
   // Number of hits and lengths of track
+  #ifdef NEW_DATAMODEL_API
   trackerHitCount_ = the_cluster.size(); // Currently a track only contains 1 cluster
+  #else
+  trackerHitCount_ = the_cluster.get_number_of_hits();
+  #endif
   trackLength_ = the_trajectory.get_pattern().get_shape().get_length();
-  
+
   if (trackLength_ == 0.0)
   {
     particleType_= UNKNOWN;
     return false;
   }
-  
+
   // Get details about the vertex position
   vertexInTracker_ = SetFoilmostVertex();
   vertexOnFoil_ = SetFoilmostVertex();
   if (SetDirection()) SetProjectedVertex(); // Can't project if no direction!
-  
+
   // ALPHA candidates are undefined charge particles associated with a delayed hit and no associated hit
   if (track_.get_charge()==snemo::datamodel::particle_track::UNDEFINED && !track_.has_associated_calorimeter_hits() && the_cluster.is_delayed()>0)
   {
     particleType_=ALPHA;
-    
+
+    #ifdef NEW_DATAMODEL_API
     const snemo::datamodel::TrackerHitHdlCollection& trackerHits = the_cluster.hits();
+    #else
+    const snemo::datamodel::calibrated_tracker_hit::collection_type& trackerHits = the_cluster.get_hits();
+    #endif
+
     // iterate only once, we only want the first hit
-    for (snemo::datamodel::TrackerHitHdlCollection::const_iterator   iHit = trackerHits.begin(); iHit > trackerHits.begin(); ++iHit) {
-      const snemo::datamodel::calibrated_tracker_hit& a_delayed_gg_hit = iHit->get();
+    for (const auto& iHit : trackerHits) {
+      const snemo::datamodel::calibrated_tracker_hit& a_delayed_gg_hit = iHit.get();
       delayTime_ = (a_delayed_gg_hit.get_delayed_time());
     }
-    
+
     return true;
   }
   // ELECTRON candidates are prompt and have an associated calorimeter hit. No charge requirement as yet
@@ -105,8 +114,8 @@ bool TrackDetails::Initialize()
     PopulateCaloHits(); // As it has an associated hit, we can calculate the hit fractions
     return true;
   }
-  
-  
+
+
   return false; // Not an alpha or an electron, what could it be?
 } // end Initialize
 
@@ -154,19 +163,23 @@ bool TrackDetails::GenerateAlphaProjections(TrackDetails *electronTrack)
   // We need to look at the hits in the alpha track, so get its associated cluster
   const snemo::datamodel::tracker_trajectory & the_trajectory = track_.get_trajectory();
   const snemo::datamodel::tracker_cluster & the_cluster = the_trajectory.get_cluster();
-  
-  std::vector<TVector3> vertexPositionDelayedHit;
-  
-  //want to store the vector position of the delayed hit
 
+  std::vector<TVector3> vertexPositionDelayedHit;
+
+  //want to store the vector position of the delayed hit
+  #ifdef NEW_DATAMODEL_API
   const snemo::datamodel::TrackerHitHdlCollection& trackerHits = the_cluster.hits();
-  for (snemo::datamodel::TrackerHitHdlCollection::const_iterator   iHit = trackerHits.begin(); iHit != trackerHits.end(); ++iHit) {
-    const snemo::datamodel::calibrated_tracker_hit& a_delayed_gg_hit = iHit->get();
+  #else
+  const snemo::datamodel::calibrated_tracker_hit::collection_type& trackerHits = the_cluster.get_hits();
+  #endif
+
+  for (const auto& iHit : trackerHits) {
+    const snemo::datamodel::calibrated_tracker_hit& a_delayed_gg_hit = iHit.get();
       TVector3 delayedHitPos;
       delayedHitPos.SetXYZ(a_delayed_gg_hit.get_x(), a_delayed_gg_hit.get_y(), a_delayed_gg_hit.get_z());
       vertexPositionDelayedHit.push_back(delayedHitPos);
   }
-  
+
   // Here we want to examine the number of hits in the alpha, then find different alpha lengths for each category
   if(trackerHitCount_ == 1){
     //Alpha length will be the distance to the prompt track
@@ -196,7 +209,7 @@ bool TrackDetails::GenerateAlphaProjections(TrackDetails *electronTrack)
     projectedLength_ = (crossesFoil_) ? alphaTrackExtension:totalDistance;
     return true;
   }
-  
+
   return false; // Zero or negative tracker hit count for the alpha
 }
 
@@ -242,12 +255,12 @@ bool TrackDetails::PopulateCaloHits()
   // There could be multiple hits for a gamma so we need to add them up
   for (unsigned int hit=0; hit<track_.get_associated_calorimeter_hits().size();++hit)
   {
-    
+
     geomtools::vector_3d loc (0,0,0);
-    
+
     const snemo::datamodel::calibrated_calorimeter_hit & calo_hit = track_.get_associated_calorimeter_hits().at(hit).get();
     double thisHitEnergy=calo_hit.get_energy();
-    
+
     // Sum the energies
     thisEnergy +=  thisHitEnergy;
     energySigmaSq += calo_hit.get_sigma_energy()*calo_hit.get_sigma_energy(); // Add in quadrature
@@ -261,7 +274,7 @@ bool TrackDetails::PopulateCaloHits()
     else if (hitType==GVETO)
       thisVetoEnergy+= thisHitEnergy;
     else cout<<"WARNING: Unknown calorimeter type "<<hitType<<endl;
-    
+
     // Get the coordinates of the hit with the earliest time
     if (firstHitTime==-1 || calo_hit.get_time()<firstHitTime)
     {
@@ -298,7 +311,7 @@ bool TrackDetails::PopulateCaloHits()
   mainwallFraction_=thisMainWallEnergy/thisEnergy;
   xwallFraction_=thisXwallEnergy/thisEnergy;
   vetoFraction_=thisVetoEnergy/thisEnergy;
-  
+
   if (track_.has_vertices()) // There isn't any time ordering to the vertices so check them all
   {
     for (unsigned int iVertex=0; iVertex<track_.get_vertices().size();++iVertex)
@@ -310,7 +323,7 @@ bool TrackDetails::PopulateCaloHits()
       }
     }
   }
-  
+
   return true;
 }
 
@@ -352,7 +365,7 @@ bool TrackDetails::SetDirection()
   const snemo::datamodel::base_trajectory_pattern & the_base_pattern = track_.get_trajectory().get_pattern();
   geomtools::vector_3d foilmost_end;
   geomtools::vector_3d outermost_end;
-  
+
   if (the_base_pattern.get_pattern_id()=="line") {
     const geomtools::line_3d & the_shape = (const geomtools::line_3d&)the_base_pattern.get_shape();
     // Find the two ends of the track
@@ -377,7 +390,7 @@ bool TrackDetails::SetDirection()
     // which is which?
     foilmost_end = ((TMath::Abs(one_end.x()) < TMath::Abs(the_other_end.x())) ? one_end: the_other_end);
     outermost_end = ((TMath::Abs(one_end.x()) >= TMath::Abs(the_other_end.x())) ? one_end: the_other_end);
-    
+
     geomtools::vector_3d direction = the_shape.get_direction_on_curve(foilmost_end); // Not the same on a curve
     int multiplier = (direction.x() * outermost_end.x() > 0)? 1: -1; // If the direction points the wrong way, reverse it
     // This will also point in towards the foil. Is that misleading in the case of a track that curves towards the foil and then out again? Not a problem when looking for bb events, but would it be misleading in cases of tracks from the wires?
@@ -396,7 +409,7 @@ bool TrackDetails::SetProjectedVertex()
 {
   // Check that we have the necessary to do this calculation
   if (GetFoilmostVertexX()==-9999 || GetDirectionX()==-9999 || GetTrackLength()==0 || !hasTrack_) return false;
-  
+
   double scale=foilmostVertex_.X()/direction_.X();
   projectedVertex_=foilmostVertex_ - scale*direction_; // The second term is the extension to the track to project it back with a straight line
   projectedLength_=trackLength_+TMath::Abs(scale*(direction_).Mag());
@@ -411,7 +424,7 @@ bool TrackDetails::SetProjectedVertex()
 }
 
 
-  
+
 // Getters for the vertex information
 
 // Foilmost vertex


### PR DESCRIPTION
To allow the integration of SensitivityModule in Falaise, this is a simple update to allow it to compile against/use the data model API from both Falaise 4 and the current develop branch.

It's a compile time test and has no effect on the use/interface of/to SensitivityModule. The behaviour and outputs should remain unchanged, as the same results are pulled from the data, just through the appropriate member functions in the two APIs.

An additional CI job has been added to test against both the develop and released versions of Falaise.