### PR TITLE
Fix issue 36

### DIFF
--- a/trackDetails.cpp
+++ b/trackDetails.cpp
@@ -72,7 +72,11 @@ bool TrackDetails::Initialize()
   trackerHitCount_ = the_cluster.size(); // Currently a track only contains 1 cluster
   trackLength_ = the_trajectory.get_pattern().get_shape().get_length();
   
-  if (trackLength_ == 0.0){return false;}
+  if (trackLength_ == 0.0)
+  {
+    particleType_= UNKNOWN;
+    return false;
+  }
   
   // Get details about the vertex position
   vertexInTracker_ = SetFoilmostVertex();

--- a/trackDetails.cpp
+++ b/trackDetails.cpp
@@ -72,6 +72,8 @@ bool TrackDetails::Initialize()
   trackerHitCount_ = the_cluster.size(); // Currently a track only contains 1 cluster
   trackLength_ = the_trajectory.get_pattern().get_shape().get_length();
   
+  if (trackLength_ == 0.0){return false;}
+  
   // Get details about the vertex position
   vertexInTracker_ = SetFoilmostVertex();
   vertexOnFoil_ = SetFoilmostVertex();


### PR DESCRIPTION
Error in SM when the track length is zero. Causes a crash called divide by zero fatal error.

If the track length is zero, TrackDetails::Initialise in trackDetails.cpp should initialise to false.